### PR TITLE
Add Angular Cameroon community, lead profile, and tech-focused

### DIFF
--- a/data/communities.json
+++ b/data/communities.json
@@ -54,5 +54,19 @@
     "description": "Django Cameroon is the official Django community in Cameroon, bringing together web developers passionate about the Django framework. We organize workshops, hackathons, and contribute to open source projects while building amazing web applications.",
     "founded_year": 2018,
     "member_count": 180
+  },
+  {
+    "name": "Angular Cameroon",
+    "focus": "Connecting and growing Angular enthusiasts across Cameroon",
+    "location": "Bamenda, Cameroon",
+    "contact": "angular.cameroon.dev@gmail.com",
+    "links": {
+      "twitter": "https://x.com/ngcameroon",
+      "linkedin": "https://www.linkedin.com/company/ngcameroon/"
+    },
+    "logo_url": "https://pbs.twimg.com/profile_images/1841848672809844737/BV6F-1Ce_400x400.jpg",
+    "description": "Angular Cameroon is a community for developers passionate about Angular. We organize meetups, workshops, and collaborative projects to help members learn, grow, and contribute to the Angular ecosystem.",
+    "founded_year": 2024,
+    "member_count": 250
   }
 ]

--- a/data/people.json
+++ b/data/people.json
@@ -45,5 +45,17 @@
     "linkedin_url": "https://linkedin.com/in/tomdieu-ivan",
     "website_url": "",
     "twitter_url": ""
+  },
+  {
+    "name": "Mofiro Jean",
+    "role": "Community Lead",
+    "interests": ["Angular", "Full-Stack Development", "Open Source", "Community Building"],
+    "availability": "Mentorship, Speaking, Workshops",
+    "avatar_url": "https://pbs.twimg.com/profile_images/1974035183528456192/773Wwegb_400x400.jpg",
+    "bio": "Mofiro Jean is a passionate Angular developer and community organizer. He leads Angular Cameroon, focusing on building a collaborative platform for developers to learn, contribute, and showcase their projects.",
+    "github_url": "https://github.com/mofirojean",
+    "twitter_url": "https://x.com/mofirojean",
+    "linkedin_url": "https://linkedin.com/in/mofirojean",
+    "website_url": "https://#"
   }
 ]

--- a/data/schools.json
+++ b/data/schools.json
@@ -28,5 +28,11 @@
     "city":"Yaounde",
     "programs":["Computer Science","Information Technology","Software Engineering"],
     "contact":"rectorat@uni-yaounde1.cm"
+  },
+  {
+    "name": "National Higher Polytechnic Institute(NAHPI)",
+    "city": "Bamenda",
+    "programs": ["Computer Science", "Software Engineering", "Information Technology", "Engineering"],
+    "contact": "info@uniba.cm"
   }
 ]


### PR DESCRIPTION
## Summary

Added the Angular Cameroon community, the community lead profile (Mofiro Jean), and a selection of tech-focused schools in Cameroon to showcase in the Djangonista project. This contribution enriches the directories for communities, people, and schools, supporting Hacktoberfest participation and the visibility of local tech initiatives.

## Testing

- [X] `uv run python manage.py test`
- [X] `uv run python manage.py check`
- [ ] Other (describe):

## Release Notes

- Added Angular Cameroon to the communities directory.
- Added Mofiro Jean as Community Lead in the people directory.
- Added three Cameroon-based tech schools to the schools directory.
- Enables Djangonista users to explore local tech communities and education resources relevant to Angular and frontend development.
